### PR TITLE
Replace IAM user with instance credentials

### DIFF
--- a/cloudInstallerScripts/roles/artifactory/templates/binarystore.xml.j2
+++ b/cloudInstallerScripts/roles/artifactory/templates/binarystore.xml.j2
@@ -36,13 +36,11 @@
     </provider>
     <provider id="s3-storage-v3" type="s3-storage-v3">
         <testConnection>false</testConnection>
-        <identity>{{ s3_access_key }}</identity>
-        <credential>{{ s3_access_secret_key }}</credential>
         <region>{{ s3_region }}</region>
         <bucketName>{{ s3_bucket }}</bucketName>
         <path>artifactory/filestore</path>
         <endpoint></endpoint>
-        <useInstanceCredentials>false</useInstanceCredentials>
+        <useInstanceCredentials>true</useInstanceCredentials>
         <usePresigning>false</usePresigning>
         <signatureExpirySeconds>300</signatureExpirySeconds>
     </provider>
@@ -84,13 +82,11 @@
     </provider>
     <provider id="s3-storage-v3" type="s3-storage-v3">
         <testConnection>false</testConnection>
-        <identity>{{ s3_access_key }}</identity>
-        <credential>{{ s3_access_secret_key }}</credential>
         <region>{{ s3_region }}</region>
         <bucketName>{{ s3_bucket }}</bucketName>
         <path>artifactory/filestore</path>
         <endpoint></endpoint>
-        <useInstanceCredentials>false</useInstanceCredentials>
+        <useInstanceCredentials>true</useInstanceCredentials>
         <usePresigning>false</usePresigning>
         <signatureExpirySeconds>300</signatureExpirySeconds>
     </provider>

--- a/scripts/configure_jcr_fargate_container.sh
+++ b/scripts/configure_jcr_fargate_container.sh
@@ -38,8 +38,6 @@ echo "Creating required directories for Artifactory configuration" | tee ${start
 mkdir -p /var/opt/jfrog/artifactory/etc/artifactory
 
 echo "Updating binarystore.xml with correct parameters" | tee ${startup_log}
-sed -i -e "s/{{ s3_access_key }}/${S3_ACCESS_KEY}/g" ${binarystore_temp}
-sed -i -e "s#{{ s3_access_secret_key }}#${S3_ACCESS_SECRET_KEY}#g" ${binarystore_temp}
 sed -i -e "s/{{ s3_region }}/${S3_REGION}/g" ${binarystore_temp}
 sed -i -e "s/{{ s3_bucket }}/${S3_BUCKET}/g" ${binarystore_temp}
 mv ${binarystore_temp} /var/opt/jfrog/artifactory/etc/artifactory

--- a/scripts/roles/artifactory/defaults/main.yml
+++ b/scripts/roles/artifactory/defaults/main.yml
@@ -10,8 +10,6 @@ db_user: artuser
 db_password: badpassword
 
 s3_region: needs_to_be_passed
-s3_access_key: needs_to_be_passed
-s3_access_secret_key: needs_to_be_passed
 s3_bucket: needs_to_be_passed
 
 # Differences required for nginx as a container.
@@ -63,4 +61,3 @@ artifactory_keystore:
 artifactory_keystore_path: /etc/alternatives/jre_1.8.0/lib/security/cacerts
 artifactory_keystore_default: changeit
 artifactory_keystore_pass: needs_to_be_passed
-

--- a/scripts/roles/artifactory/templates/binarystore.xml.j2
+++ b/scripts/roles/artifactory/templates/binarystore.xml.j2
@@ -36,13 +36,11 @@
     </provider>
     <provider id="s3-storage-v3" type="s3-storage-v3">
         <testConnection>false</testConnection>
-        <identity>{{ s3_access_key }}</identity>
-        <credential>{{ s3_access_secret_key }}</credential>
         <region>{{ s3_region }}</region>
         <bucketName>{{ s3_bucket }}</bucketName>
         <path>artifactory/filestore</path>
         <endpoint></endpoint>
-        <useInstanceCredentials>false</useInstanceCredentials>
+        <useInstanceCredentials>true</useInstanceCredentials>
         <usePresigning>false</usePresigning>
         <signatureExpirySeconds>300</signatureExpirySeconds>
     </provider>
@@ -84,13 +82,11 @@
     </provider>
     <provider id="s3-storage-v3" type="s3-storage-v3">
         <testConnection>false</testConnection>
-        <identity>{{ s3_access_key }}</identity>
-        <credential>{{ s3_access_secret_key }}</credential>
         <region>{{ s3_region }}</region>
         <bucketName>{{ s3_bucket }}</bucketName>
         <path>artifactory/filestore</path>
         <endpoint></endpoint>
-        <useInstanceCredentials>false</useInstanceCredentials>
+        <useInstanceCredentials>true</useInstanceCredentials>
         <usePresigning>false</usePresigning>
         <signatureExpirySeconds>300</signatureExpirySeconds>
     </provider>

--- a/scripts/roles/artifactory/templates/jcr_binarystore.xml.j2
+++ b/scripts/roles/artifactory/templates/jcr_binarystore.xml.j2
@@ -16,13 +16,11 @@
     </provider>
     <provider id="s3-storage-v3" type="s3-storage-v3">
         <testConnection>false</testConnection>
-        <identity>{{ s3_access_key }}</identity>
-        <credential>{{ s3_access_secret_key }}</credential>
         <region>{{ s3_region }}</region>
         <bucketName>{{ s3_bucket }}</bucketName>
         <path>artifactory/filestore</path>
         <endpoint></endpoint>
-        <useInstanceCredentials>false</useInstanceCredentials>
+        <useInstanceCredentials>true</useInstanceCredentials>
         <usePresigning>false</usePresigning>
         <signatureExpirySeconds>300</signatureExpirySeconds>
     </provider>

--- a/templates/jfrog-artifactory-core-infrastructure.template.yaml
+++ b/templates/jfrog-artifactory-core-infrastructure.template.yaml
@@ -48,9 +48,6 @@ Parameters:
     Type: String
   DatabaseName:
     Type: String
-  ArtifactoryS3IAMUser:
-    NoEcho: 'true'
-    Type: String
   ArtifactoryProduct:
     Default: JFrog-Artifactory-Pro
     Type: String
@@ -59,6 +56,8 @@ Parameters:
     Type: String
   InstanceType:
     Default: m5.xlarge
+    Type: String
+  ArtifactoryHostRole:
     Type: String
 
 Mappings:
@@ -329,8 +328,8 @@ Resources:
                 - - !Sub "arn:${AWS::Partition}:s3:::"
                   - !Ref ArtifactoryS3Bucket
                   - "/*"
-      Users:
-        - !Ref ArtifactoryS3IAMUser
+      Roles:
+        - !Ref ArtifactoryHostRole
 Outputs:
   S3Bucket:
     Value: !Ref ArtifactoryS3Bucket

--- a/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
+++ b/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
@@ -610,12 +610,7 @@ Resources:
         EnableX11Forwarding: !Ref BastionEnableX11Forwarding
         AlternativeIAMRole: !Ref BastionRole
         NumBastionHosts: !Ref NumBastionHosts
-  ArtifactoryS3IAMUser:
-    Type: AWS::IAM::User
-  ArtifactoryIamAcessKey:
-    Type: AWS::IAM::AccessKey
-    Properties:
-      UserName: !Ref ArtifactoryS3IAMUser
+
   ArtifactoryCoreInfraStack:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -638,8 +633,8 @@ Resources:
         DatabasePassword: !Ref DatabasePassword
         DatabaseInstance: !Ref DatabaseInstance
         DatabaseName: !Ref DatabaseName
-        ArtifactoryS3IAMUser: !Ref ArtifactoryS3IAMUser
         InstanceType: !Ref InstanceType
+        ArtifactoryHostRole: !Ref ArtifactoryHostRole
   ArtifactoryElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -771,7 +766,7 @@ Resources:
         - IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
   ArtifactoryHostRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       Path: /
       AssumeRolePolicyDocument:
@@ -821,8 +816,9 @@ Resources:
                   - "s3:GetObject"
                 Resource: "*"
   ArtifactoryHostProfile:
-    Type: 'AWS::IAM::InstanceProfile'
+    Type: AWS::IAM::InstanceProfile
     Properties:
+      InstanceProfileName: ArtifactoryHostProfile
       Roles:
         - !Ref ArtifactoryHostRole
       Path: /
@@ -852,7 +848,6 @@ Resources:
               - UsingDefaultBucket
               - !Ref 'AWS::Region'
               - !Ref 'QsS3BucketRegion'
-        AmiId: !Join ['', !Split [".", !Ref ArtifactoryVersion]]
         ArtifactoryProduct: !Ref ArtifactoryProduct
         ArtifactoryLicense1: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:ArtifactoryLicense1}}', '']
         ArtifactoryLicense2: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:ArtifactoryLicense2}}', '']
@@ -865,8 +860,6 @@ Resources:
         Certificate: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:Certificate}}', '']
         CertificateKey: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:CertificateKey}}', '']
         CertificateDomain: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:CertificateDomain}}', '']
-        ArtifactoryIamAcessKey: !Ref ArtifactoryIamAcessKey
-        SecretAccessKey: !GetAtt ArtifactoryIamAcessKey.SecretAccessKey
         ArtifactoryS3Bucket: !GetAtt ArtifactoryCoreInfraStack.Outputs.S3Bucket
         DatabaseUrl: !GetAtt ArtifactoryCoreInfraStack.Outputs.DatabaseUrl
         DatabaseDriver: !GetAtt ArtifactoryCoreInfraStack.Outputs.DatabaseDriver
@@ -918,8 +911,6 @@ Resources:
         Certificate: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:Certificate}}', '']
         CertificateKey: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:CertificateKey}}', '']
         CertificateDomain: !If [SmLicenseCertNameExists, !Sub '{{resolve:secretsmanager:${SmLicenseCertName}:SecretString:CertificateDomain}}', '']
-        ArtifactoryIamAcessKey: !Ref ArtifactoryIamAcessKey
-        SecretAccessKey: !GetAtt ArtifactoryIamAcessKey.SecretAccessKey
         ArtifactoryS3Bucket: !GetAtt ArtifactoryCoreInfraStack.Outputs.S3Bucket
         DatabaseUrl: !GetAtt ArtifactoryCoreInfraStack.Outputs.DatabaseUrl
         DatabaseDriver: !GetAtt ArtifactoryCoreInfraStack.Outputs.DatabaseDriver
@@ -956,7 +947,7 @@ Resources:
               - !Ref 'QsS3BucketRegion'
   XrayHostRole:
     Condition: EnableXray
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       Path: /
       AssumeRolePolicyDocument:
@@ -988,8 +979,9 @@ Resources:
                 Resource: "*"
   XrayHostProfile:
     Condition: EnableXray
-    Type: 'AWS::IAM::InstanceProfile'
+    Type: AWS::IAM::InstanceProfile
     Properties:
+      InstanceProfileName: XrayHostProfile
       Roles:
         - !Ref XrayHostRole
       Path: /

--- a/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
+++ b/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
@@ -818,7 +818,7 @@ Resources:
   ArtifactoryHostProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: ArtifactoryHostProfile
+      InstanceProfileName: !Ref ArtifactoryHostRole
       Roles:
         - !Ref ArtifactoryHostRole
       Path: /
@@ -981,7 +981,7 @@ Resources:
     Condition: EnableXray
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: XrayHostProfile
+      InstanceProfileName: !Ref XrayHostRole
       Roles:
         - !Ref XrayHostRole
       Path: /

--- a/templates/jfrog-artifactory-ec2-instance.template.yaml
+++ b/templates/jfrog-artifactory-ec2-instance.template.yaml
@@ -50,12 +50,6 @@ Parameters:
     Type: String
   EnableSSL:
     Type: String
-  ArtifactoryIamAcessKey:
-    Type: String
-    NoEcho: 'true'
-  SecretAccessKey:
-    Type: String
-    NoEcho: 'true'
   ArtifactoryS3Bucket:
     Type: String
   DatabaseUrl:
@@ -254,8 +248,6 @@ Resources:
                       artifactory_server_name: ${ArtifactoryServerName}
                       server_name: ${ArtifactoryServerName}.${CertificateDomain}
                       s3_region: ${AWS::Region}
-                      s3_access_key: ${ArtifactoryIamAcessKey}
-                      s3_access_secret_key: ${SecretAccessKey}
                       s3_bucket: ${ArtifactoryS3Bucket}
                       certificate: ${Certificate}
                       certificate_key: ${CertificateKey}


### PR DESCRIPTION
Branch based on https://github.com/jfrog/quickstart-jfrog-artifactory/tree/pro

Blocked until #42 is merged and this PR is rebased.

- Removed IAM user creation
- Removed all usage of access key and secret key
- Switched on `useInstanceCredentials` for binarystore template