### PR TITLE
Persist data across instance

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -14,10 +14,13 @@ project:
     QsS3KeyPrefix       : "quickstart-jfrog-artifactory/"
     QsS3BucketRegion    : "$[taskcat_current_region]"
     MasterKey           : "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    SmLicenseCertName   : "jfrog-artifactory"
 
     # Set this to your home intenet gateway public IP in override file
     # e.g. "24.4.228.4/32"
+    AccessCidr          : "63.238.166.122/29" # JFrog network
     RemoteAccessCidr    : "63.238.166.122/29" # JFrog network
+
 
   regions:
     - us-east-1
@@ -109,7 +112,6 @@ tests:
       us-gov-east-1: gov
     parameters:
       ArtifactoryProduct: "JFrog-Artifactory-Enterprise"
-      AccessCidr: "0.0.0.0/0"
       DatabaseInstance: "db.m5.large"
       DatabasePassword: "$[taskcat_genpass_8A]"
       MultiAzDatabase: "true"
@@ -137,7 +139,6 @@ tests:
       us-gov-east-1: gov
     parameters:
       ArtifactoryProduct: "JFrog-Artifactory-Enterprise"
-      AccessCidr: "0.0.0.0/0"
       DatabasePassword: "$[taskcat_genpass_8A]"
       MultiAzDatabase: "true"
       DatabaseInstance: "db.m5.large"
@@ -212,7 +213,6 @@ tests:
   rt-xray-ec2-marketplace:
     parameters:
       DatabaseEngine: Postgres
-      AccessCidr: "0.0.0.0/0"
       DatabasePassword: "$[taskcat_genpass_8A]"
       DatabaseInstance: "db.m5.large"
       NumberOfSecondary: "2"
@@ -275,7 +275,6 @@ tests:
 
   # rt-ecs:
   #   parameters:
-  #     AccessCidr: "0.0.0.0/0"
   #     DatabasePassword: "$[taskcat_genpass_8A]"
   #     # DatabaseInstance: "db.m5.large"
   #     # DatabaseEngine: MySQL
@@ -301,34 +300,3 @@ tests:
 
   #   regions:
   #     - us-east-2
-
-  # rt-eks:
-  #   auth:
-  #     default: temp
-  #   parameters:
-  #     AccessCidr: "0.0.0.0/0"
-  #     AvailabilityZones: "$[taskcat_genaz_3]"
-  #     DatabasePassword: "$[taskcat_genpass_8A]"
-  #     DatabaseInstance: "db.m5.large"
-  #     NumberOfSecondary: "2"
-  #     ArtifactoryServerName: "artifactory"
-  #     SmLicenseCertName: "jfrog-artifactory"
-  #     MultiAzDatabase: "false"
-  #     InstallXray: "true"
-  #     XrayHelmChartVersion: 3.10.3
-  #     XrayDatabasePassword: "$[taskcat_genpass_8A]"
-  #     XrayNumberOfSecondary: 1
-  #     RabbitMQPassword: "$[taskcat_genpass_8A]"
-  #   template: templates/jfrog-artifactory-eks-master.template.yaml
-  #   regions:
-  #     - us-west-2
-
-  # rt-eks-core:
-  #   parameters:
-  #     ArtifactoryDeploymentSize: Medium
-  #     DatabaseEngine: Postgres
-  #     DatabaseName: artdb
-  #     DatabaseUser: artifactory
-  #     KubeConfigKmsContext: JFrogArtifactory
-  #     NumberOfSecondary: 2
-  #   template: templates/jfrog-artifactory-eks-core-workload.template.yaml

--- a/cloudInstallerScripts/roles/artifactory-ami/tasks/main.yml
+++ b/cloudInstallerScripts/roles/artifactory-ami/tasks/main.yml
@@ -44,12 +44,15 @@
     group: "{{ artifactory_group }}"
   become: yes
 
-- name: ensure etc exists
+- name: ensure data subdirectories exist
   file:
-    path: "{{ artifactory_home }}/var/etc"
+    path: "{{ artifactory_home }}/var/{{ item }}"
     state: directory
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
+  loop:
+    - "bootstrap"
+    - "etc"
   become: yes
 
 - name: download database driver
@@ -60,19 +63,20 @@
     group: "{{ artifactory_group }}"
   become: yes
 
-- name: Remove SSH keys
-  file:
-    path: "{{ ssh_keys.dir }}"
-    state: absent
-  loop:
-    - dir: "/home/.jfrog_ami/.ssh/authorized_keys"
-    - dir: "/root/.ssh/authorized_keys"
-    - dir: "/home/centos/.ssh/authorized_keys"
-  loop_control:
-    loop_var: ssh_keys
-  when: ami_creation
+- name: clean up after creating ami
+  block:
+    - name: Remove SSH keys
+      file:
+        path: "{{ ssh_keys.dir }}"
+        state: absent
+      loop:
+        - dir: "/home/.jfrog_ami/.ssh/authorized_keys"
+        - dir: "/root/.ssh/authorized_keys"
+        - dir: "/home/centos/.ssh/authorized_keys"
+      loop_control:
+        loop_var: ssh_keys
 
-- name: shutdown VM
-  command: /sbin/shutdown -h now
-  ignore_errors: 'yes'
+    - name: shutdown VM
+      command: /sbin/shutdown -h now
+      ignore_errors: 'yes'
   when: ami_creation

--- a/cloudInstallerScripts/roles/artifactory/defaults/main.yml
+++ b/cloudInstallerScripts/roles/artifactory/defaults/main.yml
@@ -4,7 +4,7 @@
 ansible_marketplace: standalone
 
 # The version of Artifactory to install
-artifactory_version: 7.10.2
+artifactory_version: 7.12.5
 
 # licenses file - specify a licenses file or specify up to 6 licenses
 artifactory_license1:
@@ -30,7 +30,7 @@ artifactory_file_store_dir: /data
 use_custom_data_directory: false
 
 # location for customer directory. Will be symlink to as artifactory/var
-custom_data_directory:
+custom_data_directory: /artifactory-user-data
 
 # Pick the Artifactory flavour to install, can be also cpp-ce, jcr, pro.
 artifactory_flavour: pro

--- a/cloudInstallerScripts/roles/artifactory/defaults/main.yml
+++ b/cloudInstallerScripts/roles/artifactory/defaults/main.yml
@@ -26,6 +26,12 @@ artifactory_download_directory: /opt/jfrog
 # The location where Artifactory should store data.
 artifactory_file_store_dir: /data
 
+# whether to customer data directory
+use_custom_data_directory: false
+
+# location for customer directory. Will be symlink to as artifactory/var
+custom_data_directory:
+
 # Pick the Artifactory flavour to install, can be also cpp-ce, jcr, pro.
 artifactory_flavour: pro
 

--- a/cloudInstallerScripts/roles/artifactory/tasks/custom-data-directory.yml
+++ b/cloudInstallerScripts/roles/artifactory/tasks/custom-data-directory.yml
@@ -1,6 +1,7 @@
 - name: setup directory symlink for using custom data directory/volume
   block:
     - name: Create a xfs filesystem on /dev/nvme1n1
+      # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
       community.general.filesystem:
         dev: /dev/nvme1n1
         fstype: xfs

--- a/cloudInstallerScripts/roles/artifactory/tasks/custom-data-directory.yml
+++ b/cloudInstallerScripts/roles/artifactory/tasks/custom-data-directory.yml
@@ -1,0 +1,42 @@
+- name: setup directory symlink for using custom data directory/volume
+  block:
+    - name: Create a xfs filesystem on /dev/nvme1n1
+      community.general.filesystem:
+        dev: /dev/nvme1n1
+        fstype: xfs
+
+    - name: ensure external data directory exists
+      file:
+        path: "{{ custom_data_directory }}"
+        state: directory
+
+    - name: Mount the EBS volume
+      ansible.posix.mount:
+        path: "{{ custom_data_directory }}"
+        src: /dev/nvme1n1
+        state: mounted
+        fstype: xfs
+
+    - name: set custom data directory permission
+      file:
+        path: "{{ custom_data_directory }}"
+        state: directory
+        recurse: yes
+        owner: "{{ artifactory_user }}"
+        group: "{{ artifactory_group }}"
+        mode: "u=rwX,g=rwX,o=rwX"
+
+    - name: remove var directory if exists
+      file:
+        path: "{{ artifactory_home }}/var"
+        state: absent
+
+    - name: symlink custom data directory to var
+      file:
+        src: "{{ custom_data_directory }}"
+        path: "{{ artifactory_home }}/var"
+        state: link
+        owner: "{{ artifactory_user }}"
+        group: "{{ artifactory_group }}"
+  become: yes
+  when: use_custom_data_directory and custom_data_directory is defined

--- a/cloudInstallerScripts/roles/artifactory/tasks/main.yml
+++ b/cloudInstallerScripts/roles/artifactory/tasks/main.yml
@@ -96,19 +96,39 @@
   become: yes
   when: binary_store_file is not defined
 
-- name: use license file
-  copy:
-    src: "{{ artifactory_license_file }}"
-    dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.cluster.license"
-  become: yes
-  when: artifactory_license_file is defined and artifactory_is_primary == true
+- name: set license for Enterprise
+  block:
+    - name: use license file
+      copy:
+        src: "{{ artifactory_license_file }}"
+        dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.cluster.license"
+      become: yes
+      when: artifactory_license_file is defined and artifactory_is_primary == true
 
-- name: use license strings
-  template:
-    src: artifactory.cluster.license.j2
-    dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.cluster.license"
-  become: yes
-  when: artifactory_license_file is not defined and artifactory_is_primary == true
+    - name: use license strings
+      template:
+        src: artifactory.cluster.license.j2
+        dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.cluster.license"
+      become: yes
+      when: artifactory_license_file is not defined and artifactory_is_primary == true
+  when: artifactory_ha_enabled
+
+- name: set license for Pro
+  block:
+    - name: use license file
+      copy:
+        src: "{{ artifactory_license_file }}"
+        dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.lic"
+      become: yes
+      when: artifactory_license_file is defined
+
+    - name: use license strings
+      template:
+        src: artifactory.pro.license.j2
+        dest: "{{ artifactory_home }}/var/etc/artifactory/artifactory.lic"
+      become: yes
+      when: artifactory_license_file is not defined
+  when: not artifactory_ha_enabled
 
 - name: create artifactory service
   shell: "{{ artifactory_home }}/app/bin/installService.sh"

--- a/cloudInstallerScripts/roles/artifactory/tasks/main.yml
+++ b/cloudInstallerScripts/roles/artifactory/tasks/main.yml
@@ -31,20 +31,23 @@
     group: "{{ artifactory_group }}"
   become: yes
 
-- name: ensure etc exists
-  file:
-    path: "{{ artifactory_home }}/var/etc"
-    state: directory
-    owner: "{{ artifactory_user }}"
-    group: "{{ artifactory_group }}"
-  become: yes
+- name: setup directory symlink for using custom data directory/volume
+  include_tasks: custom-data-directory.yml
+  when: use_custom_data_directory and custom_data_directory is defined
 
-- name: ensure data folder exists and has correct ownership
+- name: ensure data subdirectories exist and have correct ownership
   file:
-    path: "{{ artifactory_home }}/var/data"
+    path: "{{ artifactory_home }}/var/{{ item }}"
     state: directory
     owner: "{{ artifactory_user }}"
     group: "{{ artifactory_group }}"
+  loop:
+    - "bootstrap"
+    - "etc"
+    - "data"
+    - "etc/info"
+    - "etc/security"
+    - "etc/artifactory"
   become: yes
 
 - name: use specified system yaml
@@ -61,14 +64,6 @@
   become: yes
   when: system_file is not defined
 
-- name: ensure {{ artifactory_home }}/var/etc/security/ exists
-  file:
-    path: "{{ artifactory_home }}/var/etc/security/"
-    state: directory
-    owner: "{{ artifactory_user }}"
-    group: "{{ artifactory_group }}"
-  become: yes
-
 - name: configure master key
   template:
     src: master.key.j2
@@ -81,26 +76,10 @@
     dest: "{{ artifactory_home }}/var/etc/security/join.key"
   become: yes
 
-- name: ensure {{ artifactory_home }}/var/etc/info/ exists
-  file:
-    path: "{{ artifactory_home }}/var/etc/info/"
-    state: directory
-    owner: "{{ artifactory_user }}"
-    group: "{{ artifactory_group }}"
-  become: yes
-
 - name: configure installer info
   template:
     src: installer-info.json.j2
     dest: "{{ artifactory_home }}/var/etc/info/installer-info.json"
-  become: yes
-
-- name: "ensure {{ artifactory_home }}/var/etc/artifactory/ exists"
-  file:
-    path: "{{ artifactory_home }}/var/etc/artifactory/"
-    state: directory
-    owner: "{{ artifactory_user }}"
-    group: "{{ artifactory_group }}"
   become: yes
 
 - name: use specified binary store

--- a/cloudInstallerScripts/roles/artifactory/templates/artifactory.pro.license.j2
+++ b/cloudInstallerScripts/roles/artifactory/templates/artifactory.pro.license.j2
@@ -1,0 +1,5 @@
+{% if artifactory_license1 %}
+{% if artifactory_license1|length %}
+{{ artifactory_license1 }}
+{% endif %}
+{% endif %}

--- a/cloudInstallerScripts/roles/xray/defaults/main.yml
+++ b/cloudInstallerScripts/roles/xray/defaults/main.yml
@@ -12,6 +12,12 @@ xray_ha_enabled: true
 # The location where xray should install.
 xray_download_directory: /opt/jfrog
 
+# whether to customer data directory
+use_custom_data_directory: false
+
+# location for customer directory. Will be symlink to as artifactory/var
+custom_data_directory:
+
 # The remote xray download file
 xray_tar: https://bintray.com/standAloneDownload/downloadArtifact?agree=true&artifactPath=/jfrog/jfrog-xray/xray-linux/{{ xray_version }}/jfrog-xray-{{ xray_version }}-linux.tar.gz&callback_id=anonymous&product=xray
 

--- a/cloudInstallerScripts/roles/xray/defaults/main.yml
+++ b/cloudInstallerScripts/roles/xray/defaults/main.yml
@@ -4,7 +4,7 @@
 ansible_marketplace: standalone
 
 # The version of xray to install
-xray_version: 3.3.0
+xray_version: 3.15.1
 
 # whether to enable HA
 xray_ha_enabled: true
@@ -16,7 +16,7 @@ xray_download_directory: /opt/jfrog
 use_custom_data_directory: false
 
 # location for customer directory. Will be symlink to as artifactory/var
-custom_data_directory:
+custom_data_directory: /xray-user-data
 
 # The remote xray download file
 xray_tar: https://bintray.com/standAloneDownload/downloadArtifact?agree=true&artifactPath=/jfrog/jfrog-xray/xray-linux/{{ xray_version }}/jfrog-xray-{{ xray_version }}-linux.tar.gz&callback_id=anonymous&product=xray

--- a/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
@@ -1,6 +1,7 @@
 - name: setup directory symlink for using custom data directory/volume
   block:
     - name: Create a xfs filesystem on /dev/nvme1n1
+      # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
       community.general.filesystem:
         dev: /dev/nvme1n1
         fstype: xfs

--- a/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
@@ -1,0 +1,42 @@
+- name: setup directory symlink for using custom data directory/volume
+  block:
+    - name: Create a xfs filesystem on /dev/nvme1n1
+      community.general.filesystem:
+        dev: /dev/nvme1n1
+        fstype: xfs
+
+    - name: ensure external data directory exists
+      file:
+        path: "{{ custom_data_directory }}"
+        state: directory
+
+    - name: Mount the EBS volume
+      ansible.posix.mount:
+        path: "{{ custom_data_directory }}"
+        src: /dev/nvme1n1
+        state: mounted
+        fstype: xfs
+
+    - name: set custom data directory permission
+      file:
+        path: "{{ custom_data_directory }}"
+        state: directory
+        recurse: yes
+        owner: "{{ xray_user }}"
+        group: "{{ xray_group }}"
+        mode: "u=rwX,g=rwX,o=rwX"
+
+    - name: remove var directory if exists
+      file:
+        path: "{{ xray_home }}/var"
+        state: absent
+
+    - name: symlink custom data directory to var
+      file:
+        src: "{{ custom_data_directory }}"
+        path: "{{ xray_home }}/var"
+        state: link
+        owner: "{{ xray_user }}"
+        group: "{{ xray_group }}"
+  become: yes
+  when: use_custom_data_directory and custom_data_directory is defined

--- a/cloudInstallerScripts/roles/xray/tasks/main.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/main.yml
@@ -18,30 +18,30 @@
     state: directory
   become: yes
 
+- name: setup directory symlink for using custom data directory/volume
+  include_tasks: custom-data-directory.yml
+  when: use_custom_data_directory and custom_data_directory is defined
 
 - name: perform prerequisite installation
   include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: ensure etc exists
+- name: ensure data subdirectories exist and have correct ownership
   file:
-    path: "{{ xray_home }}/var/etc"
+    path: "{{ xray_home }}/var/{{ item }}"
     state: directory
     owner: "{{ xray_user }}"
     group: "{{ xray_group }}"
+  loop:
+    - "etc"
+    - "data"
+    - "etc/info"
+    - "etc/security"
   become: yes
 
 - name: configure system yaml
   template:
     src: system.yaml.j2
     dest: "{{ xray_home }}/var/etc/system.yaml"
-  become: yes
-
-- name: ensure {{ xray_home }}/var/etc/security/ exists
-  file:
-    path: "{{ xray_home }}/var/etc/security/"
-    state: directory
-    owner: "{{ xray_user }}"
-    group: "{{ xray_group }}"
   become: yes
 
 - name: configure master key
@@ -54,14 +54,6 @@
   template:
     src: join.key.j2
     dest: "{{ xray_home }}/var/etc/security/join.key"
-  become: yes
-
-- name: ensure {{ xray_home }}/var/etc/info/ exists
-  file:
-    path: "{{ xray_home }}/var/etc/info/"
-    state: directory
-    owner: "{{ xray_user }}"
-    group: "{{ xray_group }}"
   become: yes
 
 - name: configure installer info

--- a/templates/jfrog-artifactory-core-infrastructure.template.yaml
+++ b/templates/jfrog-artifactory-core-infrastructure.template.yaml
@@ -1,6 +1,10 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'JFrog Artifactory Quick Start Deployment (qs-1qpmmjh61)'
 Parameters:
+  AvailabilityZones:
+    Description: List of Availability Zones to use for the subnets in the VPC. Two
+      Availability Zones are used for this deployment.
+    Type: List<AWS::EC2::AvailabilityZone::Name>
   VpcId:
     Type: AWS::EC2::VPC::Id
   VpcCidr:
@@ -59,6 +63,8 @@ Parameters:
     Type: String
   ArtifactoryHostRole:
     Type: String
+  VolumeSize:
+    Type: Number
 
 Mappings:
   DatabaseMap:
@@ -330,6 +336,42 @@ Resources:
                   - "/*"
       Roles:
         - !Ref ArtifactoryHostRole
+  ArtifactoryEbsVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone:
+        !If
+          - IsMultiAzDatabase
+          - !Select
+            - '0'
+            - !Ref AvailabilityZones
+          - !Ref DatabasePreferredAz
+      Encrypted: false
+      Size: !Ref VolumeSize
+      Tags:
+        - Key: Name
+          Value: !Sub "Artifactory-${AWS::StackName}"
+      VolumeType: gp2
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+  XrayEbsVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      AvailabilityZone:
+        !If
+          - IsMultiAzDatabase
+          - !Select
+            - '0'
+            - !Ref AvailabilityZones
+          - !Ref DatabasePreferredAz
+      Encrypted: false
+      Size: !Ref VolumeSize
+      Tags:
+        - Key: Name
+          Value: !Sub "Xray-${AWS::StackName}"
+      VolumeType: gp2
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
 Outputs:
   S3Bucket:
     Value: !Ref ArtifactoryS3Bucket
@@ -389,3 +431,7 @@ Outputs:
       }
   DeploymentSize:
     Value: !FindInMap [JavaOptionstoInstance, !Ref InstanceType, DeploymentSize]
+  ArtifactoryEbsVolume:
+    Value: !Ref ArtifactoryEbsVolume
+  XrayEbsVolume:
+    Value: !Ref XrayEbsVolume

--- a/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
+++ b/templates/jfrog-artifactory-ec2-existing-vpc.template.yaml
@@ -14,6 +14,7 @@ Metadata:
       - Label:
           default: Network configuration
         Parameters:
+          - AvailabilityZones
           - VpcId
           - VpcCidr
           - PublicSubnet1Id
@@ -78,6 +79,8 @@ Metadata:
           - XrayDatabaseUser
           - XrayDatabasePassword
     ParameterLabels:
+      AvailabilityZones:
+        default: Availability Zones
       KeyPairName:
         default: SSH key name
       VpcId:
@@ -175,6 +178,10 @@ Metadata:
       XrayDatabasePassword:
         default: Xray Database password
 Parameters:
+  AvailabilityZones:
+    Description: List of Availability Zones to use for the subnets in the VPC. Two
+      Availability Zones are used for this deployment.
+    Type: List<AWS::EC2::AvailabilityZone::Name>
   KeyPairName:
     Description: Name of an existing key pair,
       which allows you to connect securely to your instance after it launches.
@@ -619,6 +626,10 @@ Resources:
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QsS3BucketName}-${AWS::Region}', !Ref 'QsS3BucketName']
           S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref 'QsS3BucketRegion']
       Parameters:
+        AvailabilityZones:
+          Fn::Join:
+            - ','
+            - Ref: AvailabilityZones
         VpcId: !Ref VpcId
         VpcCidr: !Ref VpcCidr
         PrivateSubnet1Cidr: !Ref PrivateSubnet1Cidr
@@ -635,6 +646,7 @@ Resources:
         DatabaseName: !Ref DatabaseName
         InstanceType: !Ref InstanceType
         ArtifactoryHostRole: !Ref ArtifactoryHostRole
+        VolumeSize: !Ref VolumeSize
   ArtifactoryElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
@@ -877,7 +889,7 @@ Resources:
         HostProfile: !Ref ArtifactoryHostProfile
         SecurityGroups: !Ref ArtifactoryEc2Sg
         InstanceType: !Ref InstanceType
-        VolumeSize: !Ref VolumeSize
+        Volume: !GetAtt ArtifactoryCoreInfraStack.Outputs.ArtifactoryEbsVolume
         TargetGroupARN: !Ref ArtifactoryTargetGroup
         SSLTargetGroupARN: !Ref ArtifactorySslTargetGroup
         InternalTargetGroupARN: !Ref ArtifactoryInternalTargetGroup
@@ -928,7 +940,7 @@ Resources:
         HostProfile: !Ref ArtifactoryHostProfile
         SecurityGroups: !Ref ArtifactoryEc2Sg
         InstanceType: !Ref InstanceType
-        VolumeSize: !Ref VolumeSize
+        Volume: !GetAtt ArtifactoryCoreInfraStack.Outputs.ArtifactoryEbsVolume
         TargetGroupARN: !Ref ArtifactoryTargetGroup
         SSLTargetGroupARN: !Ref ArtifactorySslTargetGroup
         InternalTargetGroupARN: !Ref ArtifactoryInternalTargetGroup
@@ -962,6 +974,25 @@ Resources:
       ManagedPolicyArns:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
       Policies:
+        - PolicyName: "JFrogAMI-policy"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "ec2:Describe*"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "ec2:AttachVolume"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "ec2:DetachVolume"
+                Resource: "*"
+              - Effect: "Allow"
+                Action:
+                  - "s3:GetObject"
+                  - "s3:ListObject"
+                  - "s3:ListBucket"
+                Resource: "*"
         - PolicyName: 'CloudWatch-policy'
           PolicyDocument:
             Version: "2012-10-17"
@@ -1020,7 +1051,7 @@ Resources:
         DatabasePassword: !Ref DatabasePassword
         MasterKey: !Ref MasterKey
         SecurityGroups: !Ref ArtifactoryEc2Sg
-        VolumeSize: !Ref VolumeSize
+        Volume: !GetAtt ArtifactoryCoreInfraStack.Outputs.XrayEbsVolume
         XrayInstanceType: !Ref XrayInstanceType
         JfrogInternalUrl: !Sub "http://${ArtifactoryInternalElb.DNSName}"
         AnsibleVaultPass: !Ref AnsibleVaultPass

--- a/templates/jfrog-artifactory-ec2-instance.template.yaml
+++ b/templates/jfrog-artifactory-ec2-instance.template.yaml
@@ -393,10 +393,11 @@ Resources:
             # Get instance id from AWS
             INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
             # Attach the volume created by another CFT
-            # the device name should become /dev/nvme1n1 because why not
+            # the device name should become /dev/nvme1n1
+            # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
             /var/awslogs/bin/aws ec2 attach-volume --volume-id ${Volume} --instance-id $INSTANCE_ID --device /dev/xvdf --region ${AWS::Region} || cfn_fail
             echo "Wait for volume to attach"
-            sleep 10
+            sleep 30 # Give volume time to attach
             lsblk # debug
 
             export ANSIBLE_VAULT_PASSWORD_FILE="/root/.vault_pass.txt"

--- a/templates/jfrog-artifactory-ec2-instance.template.yaml
+++ b/templates/jfrog-artifactory-ec2-instance.template.yaml
@@ -90,8 +90,8 @@ Parameters:
     Type: String
   InstanceType:
     Type: String
-  VolumeSize:
-    Type: Number
+  Volume:
+    Type: String
   KeystorePassword:
     Description: Default Keystore from Java in which we upgrade.
     Type: String
@@ -100,6 +100,11 @@ Parameters:
     Description: Ansiblevault Password to secure the artifactory.yml
     Type: String
     NoEcho: 'true'
+  UserDataDirectory:
+    Description: Directory to store Artifactory data. Can be used to store data (via symlink) in detachable volume
+    Type: String
+    Default: '/artifactory-user-data'
+
 # To populate additional mappings use the following with the desired --region
 # aws --region us-west-2 ec2 describe-images --owners amazon --filters 'Name=name,Values=amzn-ami-hvm-2018.03.0.20181129-x86_64-gp2' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'
 Mappings:
@@ -220,13 +225,13 @@ Resources:
                   - import_playbook: artifactory-ami.yml
                     vars:
                       ami_creation: false
+                      artifactory_flavour: "pro"
+                      artifactory_ha_enabled: false
+                      artifactory_tar: "https://dl.bintray.com/jfrog/artifactory-pro/org/artifactory/pro/jfrog-artifactory-pro/${ArtifactoryVersion}/jfrog-artifactory-pro-${ArtifactoryVersion}-linux.tar.gz"
                       artifactory_version: ${ArtifactoryVersion}
-                      artifactory_ha_enabled: true
                       db_download_url: "https://jdbc.postgresql.org/download/postgresql-42.2.12.jar"
                       db_type: "postgresql"
                       db_driver: "org.postgresql.Driver"
-                      artifactory_flavour: "pro"
-                      artifactory_tar: "https://dl.bintray.com/jfrog/artifactory-pro/org/artifactory/pro/jfrog-artifactory-pro/${ArtifactoryVersion}/jfrog-artifactory-pro-${ArtifactoryVersion}-linux.tar.gz"
               mode: "0400"
         config-artifactory-master:
           files:
@@ -247,6 +252,8 @@ Resources:
                       artifactory_is_primary: ${ArtifactoryPrimary}
                       artifactory_server_name: ${ArtifactoryServerName}
                       server_name: ${ArtifactoryServerName}.${CertificateDomain}
+                      use_custom_data_directory: true
+                      custom_data_directory: "${UserDataDirectory}"
                       s3_region: ${AWS::Region}
                       s3_bucket: ${ArtifactoryS3Bucket}
                       certificate: ${Certificate}
@@ -297,13 +304,6 @@ Resources:
       SecurityGroups:
         - !Ref SecurityGroups
       InstanceType: !Ref InstanceType
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref VolumeSize
-            VolumeType: gp2
-            DeleteOnTermination: true
-            Encrypted: true
       UserData:
         Fn::Base64:
           !Sub |
@@ -390,7 +390,18 @@ Resources:
             chmod +x ./awslogs-agent-setup.py
             ./awslogs-agent-setup.py -n -r ${AWS::Region} -c /root/cloudwatch.conf
 
+            # Get instance id from AWS
+            INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+            # Attach the volume created by another CFT
+            # the device name should become /dev/nvme1n1 because why not
+            /var/awslogs/bin/aws ec2 attach-volume --volume-id ${Volume} --instance-id $INSTANCE_ID --device /dev/xvdf --region ${AWS::Region} || cfn_fail
+            echo "Wait for volume to attach"
+            sleep 10
+            lsblk # debug
+
             export ANSIBLE_VAULT_PASSWORD_FILE="/root/.vault_pass.txt"
+
+            ansible-galaxy collection install community.general ansible.posix
 
             setsebool httpd_can_network_connect 1 -P
 

--- a/templates/jfrog-artifactory-ec2-master.template.yaml
+++ b/templates/jfrog-artifactory-ec2-master.template.yaml
@@ -565,6 +565,10 @@ Resources:
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QsS3BucketName}-${AWS::Region}', !Ref 'QsS3BucketName']
           S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref 'QsS3BucketRegion']
       Parameters:
+        AvailabilityZones:
+          Fn::Join:
+            - ','
+            - Ref: AvailabilityZones
         KeyPairName: !Ref KeyPairName
         VpcId: !GetAtt ArtifactoryVpcStack.Outputs.VPCID
         VpcCidr: !Ref VpcCidr

--- a/templates/jfrog-artifactory-pro-ec2-existing-vpc-master.template.yaml
+++ b/templates/jfrog-artifactory-pro-ec2-existing-vpc-master.template.yaml
@@ -299,6 +299,7 @@ Resources:
         - S3Bucket: !If [UsingDefaultBucket, !Sub '${QsS3BucketName}-${AWS::Region}', !Ref 'QsS3BucketName']
           S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref 'QsS3BucketRegion']
       Parameters:
+        AvailabilityZones: !Join [',', [!Ref DatabasePreferredAz]]
         KeyPairName: !Ref KeyPairName
         ProvisionBastionHost: "Disabled"
         AccessCidr: !Ref AccessCidr

--- a/templates/jfrog-xray-ec2-instance.template.yaml
+++ b/templates/jfrog-xray-ec2-instance.template.yaml
@@ -41,8 +41,6 @@ Parameters:
     NoEcho: 'true'
   SecurityGroups:
     Type: String
-  VolumeSize:
-    Type: Number
   XrayHostProfile:
     Type: String
   XrayHostRole:
@@ -55,6 +53,8 @@ Parameters:
     Description: Ansiblevault Password to secure the artifactory.yml
     Type: String
     NoEcho: 'true'
+  Volume:
+    Type: String
   XrayDatabaseUser:
     Type: String
   XrayDatabasePassword:
@@ -69,6 +69,10 @@ Parameters:
     Type: String
   XrayVersion:
     Type: String
+  UserDataDirectory:
+    Description: Directory to store Artifactory data. Can be used to store data (via symlink) in detachable volume
+    Type: String
+    Default: '/xray-user-data'
 
 # To populate additional mappings use the following with the desired --region
 # aws --region us-west-2 ec2 describe-images --owners amazon --filters 'Name=name,Values=amzn-ami-hvm-2018.03.0.20181129-x86_64-gp2' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'
@@ -186,6 +190,7 @@ Resources:
                       db_type: postgresql
                       db_driver: org.postgresql.Driver
                       xray_version: ${XrayVersion}
+                      xray_ha_enabled: false
               mode: "0400"
         config-xray:
           files:
@@ -195,6 +200,8 @@ Resources:
                   - import_playbook: site-xray.yml
                     vars:
                       jfrog_url: ${JfrogInternalUrl}
+                      use_custom_data_directory: true
+                      custom_data_directory: "${UserDataDirectory}"
                       master_key: ${MasterKey}
                       join_key: ${MasterKey}
                       db_type: ${DatabaseType}
@@ -219,13 +226,6 @@ Resources:
       SecurityGroups:
         - !Ref SecurityGroups
       InstanceType: !Ref XrayInstanceType
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref VolumeSize
-            VolumeType: gp2
-            DeleteOnTermination: true
-            Encrypted: true
       UserData:
         Fn::Base64:
           !Sub |
@@ -309,6 +309,15 @@ Resources:
             chmod +x ./awslogs-agent-setup.py
             ./awslogs-agent-setup.py -n -r ${AWS::Region} -c /root/cloudwatch.conf
 
+            # Get instance id from AWS
+            INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+            # Attach the volume created by another CFT
+            # the device name should become /dev/nvme1n1 because why not
+            /var/awslogs/bin/aws ec2 attach-volume --volume-id ${Volume} --instance-id $INSTANCE_ID --device /dev/xvdf --region ${AWS::Region} || cfn_fail
+            echo "Wait for volume to attach"
+            sleep 10
+            lsblk # debug
+
             # CentOS cloned virtual machines do not create a new machine id
             # https://www.thegeekdiary.com/centos-rhel-7-how-to-change-the-machine-id/
             rm -f /etc/machine-id
@@ -321,6 +330,8 @@ Resources:
                 psql postgresql://${DatabaseUser}:${DatabasePassword}@${XrayMasterDatabaseUrl} -c "CREATE DATABASE xraydb WITH OWNER=${XrayDatabaseUser} ENCODING='UTF8'" &>> /var/log/userdata.xray_database.log;
                 psql postgresql://${DatabaseUser}:${DatabasePassword}@${XrayMasterDatabaseUrl} -c "GRANT ALL PRIVILEGES ON DATABASE xraydb TO ${XrayDatabaseUser}" &>> /var/log/userdata.xray_database.log;
             fi
+
+            ansible-galaxy collection install community.general ansible.posix
 
             ansible-playbook /root/.xray_ami/xray-ami-setup.yml 2>&1 | tee /var/log/xray-ami.log || cfn_fail
             ansible-playbook /root/.xray_ami/xray.yml 2>&1 | tee /var/log/xray.log || qs_err " ansible execution failed "

--- a/templates/jfrog-xray-ec2-instance.template.yaml
+++ b/templates/jfrog-xray-ec2-instance.template.yaml
@@ -311,10 +311,11 @@ Resources:
             # Get instance id from AWS
             INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
             # Attach the volume created by another CFT
-            # the device name should become /dev/nvme1n1 because why not
+            # the device name should become /dev/nvme1n1
+            # See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
             /var/awslogs/bin/aws ec2 attach-volume --volume-id ${Volume} --instance-id $INSTANCE_ID --device /dev/xvdf --region ${AWS::Region} || cfn_fail
             echo "Wait for volume to attach"
-            sleep 10
+            sleep 30 # Give volume time to attach
             lsblk # debug
 
             # CentOS cloned virtual machines do not create a new machine id

--- a/templates/jfrog-xray-ec2-instance.template.yaml
+++ b/templates/jfrog-xray-ec2-instance.template.yaml
@@ -138,7 +138,7 @@ Resources:
   XrayLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
     Metadata:
-      'AWS::CloudFormation::Authentication':
+      AWS::CloudFormation::Authentication:
         S3AccessCreds:
           type: S3
           roleName:
@@ -216,7 +216,6 @@ Resources:
                 ${AnsibleVaultPass}
               mode: "0400"
     Properties:
-      AssociatePublicIpAddress: true
       KeyName: !Ref KeyPairName
       IamInstanceProfile: !Ref XrayHostProfile
       ImageId: !FindInMap


### PR DESCRIPTION
https://www.jfrog.com/jira/browse/PTRENG-1539

- Move EC2 volume from part of LaunchConfiguration to own CFT in the core infrastructure template. This retains the volume when instance is replaced (vis ASG scaling) or CloudFormation update (e.g. version grade)
- Replace IAM user for S3 access with IAM role
- Output license file for Pro
- Remove public IP address for Xray instance
- Replace open address CIDR with specific one in taskcat config