### PR TITLE
Install python3 for centos7

### DIFF
--- a/cloudInstallerScripts/roles/artifactory-nginx-ami/tasks/main.yml
+++ b/cloudInstallerScripts/roles/artifactory-nginx-ami/tasks/main.yml
@@ -3,11 +3,15 @@
   yum:
     name: epel-release
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: Install nginx
   yum:
     name: nginx
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: configure main nginx conf file.
   copy:

--- a/cloudInstallerScripts/roles/artifactory-nginx-ssl/tasks/main.yml
+++ b/cloudInstallerScripts/roles/artifactory-nginx-ssl/tasks/main.yml
@@ -38,6 +38,8 @@
     target: '/var/opt/jfrog/nginx/ssl/cert.pem'
     setype: httpd_sys_content_t
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
   become: yes
 
 - name: Apply new SELinux file context to filesystem

--- a/cloudInstallerScripts/roles/xray-ami/tasks/RedHat.yml
+++ b/cloudInstallerScripts/roles/xray-ami/tasks/RedHat.yml
@@ -3,14 +3,19 @@
   yum:
     name: "{{ xray_home }}/app/third-party/misc/libdb-utils-5.3.21-19.el7.x86_64.rpm"
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: Install socat
   yum:
     name: "{{ xray_home }}/app/third-party/rabbitmq/socat-1.7.3.2-2.el7.x86_64.rpm"
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: Install erlang
   yum:
     name: "{{ xray_home }}/app/third-party/rabbitmq/erlang-22.3.4-1.el7.x86_64.rpm"
     state: present
-
+  vars:
+    ansible_python_interpreter: /bin/python2

--- a/cloudInstallerScripts/roles/xray/tasks/RedHat.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/RedHat.yml
@@ -3,14 +3,19 @@
   yum:
     name: "{{ xray_home }}/app/third-party/misc/libdb-utils-5.3.21-19.el7.x86_64.rpm"
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: Install socat
   yum:
     name: "{{ xray_home }}/app/third-party/rabbitmq/socat-1.7.3.2-2.el7.x86_64.rpm"
     state: present
+  vars:
+    ansible_python_interpreter: /bin/python2
 
 - name: Install erlang
   yum:
     name: "{{ xray_home }}/app/third-party/rabbitmq/erlang-22.3.4-1.el7.x86_64.rpm"
     state: present
-
+  vars:
+    ansible_python_interpreter: /bin/python2

--- a/templates/jfrog-artifactory-ec2-instance.template.yaml
+++ b/templates/jfrog-artifactory-ec2-instance.template.yaml
@@ -333,50 +333,40 @@ Resources:
 
             S3URI=${QsS3Uri}
 
-            yum install -y git
+            # Update OS
+            yum update -y
+
+            # Install git
+            yum install -y git policycoreutils-python
+
+            yum update --security -y 2>&1 | tee /var/log/userdata.yum_security_update.log
+
+            yum install -y python3 libselinux-python3
 
             echo $PATH
 
             PATH=/opt/aws/bin:$PATH
 
             echo $PATH
-            echo \'[Cloning: Load QuickStart Common Utils]\'
 
-            git clone https://github.com/aws-quickstart/quickstart-linux-utilities.git
+            # Create virtual env and activate
+            python3 -m venv ~/venv --system-site-packages
+            source ~/venv/bin/activate
 
-            source /quickstart-linux-utilities/quickstart-cfn-tools.source
+            pip install --upgrade pip
 
-            echo \'[Loaded: Load QuickStart Common Utils]\'
+            # Install Cloudformation helper scripts
+            pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log
 
-            echo \'[Update Operating System]\'
+            pip install awscli 2>&1 | tee /var/log/userdata.awscli_install.log
 
-            qs_update-os || qs_err
-
-            qs_bootstrap_pip || qs_err
-
-            qs_aws-cfn-bootstrap || qs_err
-
-            pip install virtualenv 2>&1 | tee /var/log/userdata.virtualenv_install.log || qs_err " virtualenv install failed "
-
-            virtualenv --system-site-packages ~/venv 2>&1 | tee /var/log/userdata.create_venv.log || qs_err " creating venv failed "
-
-            source ~/venv/bin/activate 2>&1 | tee /var/log/userdata.activate_venv.log || qs_err " activate venv failed "
-
-            pip install awscli 2>&1 | tee /var/log/userdata.awscli_install.log || qs_err " awscli install failed "
-
-            pip install ansible 2>&1 | tee /var/log/userdata.ansible_install.log || qs_err " ansible install failed "
-
-            pip install selinux 2>&1 | tee /var/log/userdata.selinux_install.log || qs_err " selinux install failed "
-
-            yum update --security -y 2>&1 | tee /var/log/userdata.yum_security_update.log || qs_err " security install failed "
+            pip install ansible 2>&1 | tee /var/log/userdata.ansible_install.log
 
             mkdir ~/.jfrog_ami
 
-            aws s3 --region ${AWS::Region} sync s3://${QsS3BucketName}/${QsS3KeyPrefix}cloudInstallerScripts/ ~/.jfrog_ami/
+            aws s3 --region ${AWS::Region} sync s3://${QsS3BucketName}/${QsS3KeyPrefix}cloudInstallerScripts/ ~/.jfrog_ami/ || cfn_fail
 
             setsebool httpd_can_network_connect 1 -P
-
-            source ~/venv/bin/activate 2>&1 | tee /var/log/userdata.activate_venv.log || qs_err " activate venv failed "
 
             # CentOS cloned virtual machines do not create a new machine id
             # https://www.thegeekdiary.com/centos-rhel-7-how-to-change-the-machine-id/
@@ -388,7 +378,7 @@ Resources:
             # Setup CloudWatch Agent
             curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
             chmod +x ./awslogs-agent-setup.py
-            ./awslogs-agent-setup.py -n -r ${AWS::Region} -c /root/cloudwatch.conf
+            ./awslogs-agent-setup.py -n -r ${AWS::Region} -c /root/cloudwatch.conf 2>&1 | tee /var/log/userdata.cloudwatch_agent_install.log
 
             # Get instance id from AWS
             INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
@@ -407,10 +397,9 @@ Resources:
             setsebool httpd_can_network_connect 1 -P
 
             ansible-playbook /root/.jfrog_ami/jfrog-ami-setup.yml 2>&1 | tee /var/log/jfrog-ami-setup.log || cfn_fail
-            ansible-playbook /root/.jfrog_ami/artifactory.yml 2>&1 | tee /var/log/jfrog-ami-artifactory.log || qs_err " ansible execution failed "
+            ansible-playbook /root/.jfrog_ami/artifactory.yml 2>&1 | tee /var/log/jfrog-ami-artifactory.log || cfn_fail
 
             rm -rf /root/.secureit.sh
 
-            $(qs_status) &> /var/log/qs_status.log
             cfn_success &> /var/log/cfn_success.log
-            [ $(qs_status) == 0 ] && cfn_success || cfn_fail
+            cfn_success || cfn_fail

--- a/templates/jfrog-xray-ec2-instance.template.yaml
+++ b/templates/jfrog-xray-ec2-instance.template.yaml
@@ -255,7 +255,9 @@ Resources:
 
             S3URI=${QsS3Uri}
 
-            yum install -y git
+            yum update --security -y &> /var/log/userdata.yum_security_update.log
+
+            yum install -y git python3 libselinux-python3
             yum install -y postgresql-server postgresql-devel
 
             echo $PATH
@@ -263,43 +265,25 @@ Resources:
             PATH=/opt/aws/bin:$PATH
 
             echo $PATH
-            echo \'[Cloning: Load QuickStart Common Utils]\'
 
-            git clone https://github.com/aws-quickstart/quickstart-linux-utilities.git
+            # Create virtual env and activate
+            python3 -m venv ~/venv --system-site-packages
+            source ~/venv/bin/activate
 
-            source /quickstart-linux-utilities/quickstart-cfn-tools.source
+            pip install --upgrade pip
 
-            echo \'[Loaded: Load QuickStart Common Utils]\'
+            # Install Cloudformation helper scripts
+            pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log
 
-            echo \'[Update Operating System]\'
+            pip install awscli &> /var/log/userdata.awscli_install.log
 
-            qs_update-os || qs_err
-
-            qs_bootstrap_pip || qs_err
-
-            qs_aws-cfn-bootstrap || qs_err
-
-            pip install virtualenv &> /var/log/userdata.virtualenv_install.log || qs_err " virtualenv install failed "
-
-            virtualenv --system-site-packages ~/venv &> /var/log/userdata.create_venv.log || qs_err " creating venv failed "
-
-            source ~/venv/bin/activate &> /var/log/userdata.activate_venv.log || qs_err " activate venv failed "
-
-            pip install awscli &> /var/log/userdata.awscli_install.log || qs_err " awscli install failed "
-
-            pip install ansible &> /var/log/userdata.ansible_install.log || qs_err " ansible install failed "
-
-            pip install selinux &> /var/log/userdata.selinux_install.log || qs_err " selinux install failed "
+            pip install ansible &> /var/log/userdata.ansible_install.log
 
             setsebool httpd_can_network_connect 1 -P
-
-            yum update --security -y &> /var/log/userdata.yum_security_update.log || qs_err " security install failed "
 
             mkdir ~/.xray_ami
 
             aws s3 --region ${AWS::Region} sync s3://${QsS3BucketName}/${QsS3KeyPrefix}cloudInstallerScripts/ ~/.xray_ami/
-
-            source ~/venv/bin/activate &> /var/log/userdata.activate_venv.log || qs_err " activate venv failed "
 
             cfn-init -v --stack ${AWS::StackName} --resource XrayLaunchConfiguration --configsets xray_install --region ${AWS::Region} || cfn_fail
 
@@ -334,8 +318,7 @@ Resources:
             ansible-galaxy collection install community.general ansible.posix
 
             ansible-playbook /root/.xray_ami/xray-ami-setup.yml 2>&1 | tee /var/log/xray-ami.log || cfn_fail
-            ansible-playbook /root/.xray_ami/xray.yml 2>&1 | tee /var/log/xray.log || qs_err " ansible execution failed "
+            ansible-playbook /root/.xray_ami/xray.yml 2>&1 | tee /var/log/xray.log || cfn_fail
 
-            $(qs_status) &> /var/log/qs_status.log
             cfn_success &> /var/log/cfn_success.log
-            [ $(qs_status) == 0 ] && cfn_success || cfn_fail
+            cfn_success || cfn_fail


### PR DESCRIPTION
- Drop quickstart-linux-utilities as it hasn’t been updated for python3
- Install cfn helper scripts directly using latest version for python3
- Use python2 for legacy Ansible tasks