### PR TITLE
Remove ebs volume for ami creation

### DIFF
--- a/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/custom-data-directory.yml
@@ -24,21 +24,21 @@
         path: "{{ custom_data_directory }}"
         state: directory
         recurse: yes
-        owner: "{{ artifactory_user }}"
-        group: "{{ artifactory_group }}"
+        owner: "{{ xray_user }}"
+        group: "{{ xray_group }}"
         mode: "u=rwX,g=rwX,o=rwX"
 
     - name: remove var directory if exists
       file:
-        path: "{{ artifactory_home }}/var"
+        path: "{{ xray_home }}/var"
         state: absent
 
     - name: symlink custom data directory to var
       file:
         src: "{{ custom_data_directory }}"
-        path: "{{ artifactory_home }}/var"
+        path: "{{ xray_home }}/var"
         state: link
-        owner: "{{ artifactory_user }}"
-        group: "{{ artifactory_group }}"
+        owner: "{{ xray_user }}"
+        group: "{{ xray_group }}"
   become: yes
   when: use_custom_data_directory and custom_data_directory is defined

--- a/cloudInstallerScripts/roles/xray/tasks/main.yml
+++ b/cloudInstallerScripts/roles/xray/tasks/main.yml
@@ -24,6 +24,10 @@
 - name: perform prerequisite installation
   include_tasks: "{{ ansible_os_family }}.yml"
 
+- name: setup directory symlink for using custom data directory/volume
+  include_tasks: custom-data-directory.yml
+  when: use_custom_data_directory and custom_data_directory is defined
+
 - name: ensure data subdirectories exist and have correct ownership
   file:
     path: "{{ xray_home }}/var/{{ item }}"

--- a/templates/ami-rt-xray-creation.template.yaml
+++ b/templates/ami-rt-xray-creation.template.yaml
@@ -17,7 +17,6 @@ Metadata:
           default: JFrog Product AMI info
         Parameters:
           - InstanceType
-          - VolumeSize
           - XrayVersion
       - Label:
           default: AWS Quick Start Configuration
@@ -36,8 +35,6 @@ Metadata:
         default: Public subnet 1 ID
       InstanceType:
         default: EC2 instance type
-      VolumeSize:
-        default: EBS root volume size
       XrayVersion:
         default: Xray version
       QsS3BucketName:
@@ -81,11 +78,6 @@ Parameters:
     ConstraintDescription: Must contain valid instance type.
     Default: m5.xlarge
     Type: String
-  VolumeSize:
-    Description: The size in GB of the available storage; the Quick Start will create an
-      Amazon Elastic Block Store (Amazon EBS) volumes of this size.
-    Default: 10
-    Type: Number
   QsS3BucketName:
     Description: S3 bucket name for the Quick Start assets. This string can include
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
@@ -146,12 +138,6 @@ Resources:
                 Action: "ec2:Describe*"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "ec2:AttachVolume"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "ec2:DetachVolume"
-                Resource: "*"
-              - Effect: "Allow"
                 Action:
                   - "s3:GetObject"
                   - "s3:ListObject"
@@ -185,13 +171,13 @@ Resources:
           files:
             /root/.xray_ami/xray-ami-setup.yml:
               content: !Sub |
-                  # Base install for Xray
-                  - import_playbook: xray-ami.yml
-                    vars:
-                      ami_creation: true
-                      db_type: postgresql
-                      db_driver: org.postgresql.Driver
-                      xray_version: ${XrayVersion}
+                # Base install for Xray
+                - import_playbook: xray-ami.yml
+                  vars:
+                    ami_creation: true
+                    db_type: postgresql
+                    db_driver: org.postgresql.Driver
+                    xray_version: ${XrayVersion}
               mode: "0400"
     Properties:
       KeyName: !Ref KeyPairName
@@ -201,13 +187,6 @@ Resources:
         - AMI
       IamInstanceProfile: !Ref JFrogAMIInstanceProfile
       InstanceType: !Ref InstanceType
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref VolumeSize
-            VolumeType: gp2
-            DeleteOnTermination: true
-            Encrypted: false
       NetworkInterfaces:
         - AssociatePublicIpAddress: True
           DeviceIndex: "0"
@@ -260,6 +239,7 @@ Resources:
             source ~/venv/bin/activate
 
             pip install --upgrade pip
+            pip install wheel
 
             # Install Cloudformation helper scripts
             pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log

--- a/templates/ami-rt-xray-master.template.yaml
+++ b/templates/ami-rt-xray-master.template.yaml
@@ -16,7 +16,6 @@ Metadata:
           default: JFrog Product AMI info
         Parameters:
           - InstanceType
-          - VolumeSize
           - XrayVersion
       - Label:
           default: AWS Quick Start Configuration
@@ -33,8 +32,6 @@ Metadata:
         default: Availability zone
       InstanceType:
         default: EC2 instance type
-      VolumeSize:
-        default: EBS root volume size
       XrayVersion:
         default: Xray version
       QsS3BucketName:
@@ -76,11 +73,6 @@ Parameters:
     ConstraintDescription: Must contain valid instance type.
     Default: m5.xlarge
     Type: String
-  VolumeSize:
-    Description: The size in GB of the available storage; the Quick Start will create an
-      Amazon Elastic Block Store (Amazon EBS) volumes of this size.
-    Default: 10
-    Type: Number
   QsS3BucketName:
     Description: S3 bucket name for the Quick Start assets. This string can include
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
@@ -129,7 +121,6 @@ Resources:
         VpcId: !GetAtt VPCStack.Outputs.VpcId
         PublicSubnet1Id: !GetAtt VPCStack.Outputs.PublicSubnetID
         InstanceType: !Ref InstanceType
-        VolumeSize: !Ref VolumeSize
         XrayVersion: !Ref XrayVersion
         QsS3BucketName: !Ref QsS3BucketName
         QsS3KeyPrefix: !Ref QsS3KeyPrefix

--- a/templates/jfrog-ami-creation.template.yaml
+++ b/templates/jfrog-ami-creation.template.yaml
@@ -17,7 +17,6 @@ Metadata:
           default: JFrog Product AMI info
         Parameters:
           - InstanceType
-          - VolumeSize
           - JFrogProduct
           - ArtifactoryVersion
       - Label:
@@ -37,8 +36,6 @@ Metadata:
         default: Public subnet 1 ID
       InstanceType:
         default: EC2 instance type
-      VolumeSize:
-        default: EBS root volume size
       JFrogProduct:
         default: JFrog Product to install
       ArtifactoryVersion:
@@ -91,11 +88,6 @@ Parameters:
     ConstraintDescription: Must contain valid instance type.
     Default: m5.xlarge
     Type: String
-  VolumeSize:
-    Description: The size in GB of the available storage; the Quick Start will create an
-      Amazon Elastic Block Store (Amazon EBS) volumes of this size.
-    Default: 10
-    Type: Number
   QsS3BucketName:
     Description: S3 bucket name for the Quick Start assets. This string can include
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
@@ -161,12 +153,6 @@ Resources:
                 Action: "ec2:Describe*"
                 Resource: "*"
               - Effect: "Allow"
-                Action: "ec2:AttachVolume"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "ec2:DetachVolume"
-                Resource: "*"
-              - Effect: "Allow"
                 Action:
                   - "s3:GetObject"
                   - "s3:ListObject"
@@ -222,13 +208,6 @@ Resources:
         - AMI
       IamInstanceProfile: !Ref JFrogAMIInstanceProfile
       InstanceType: !Ref InstanceType
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: !Ref VolumeSize
-            VolumeType: gp2
-            DeleteOnTermination: true
-            Encrypted: false
       NetworkInterfaces:
         - AssociatePublicIpAddress: True
           DeviceIndex: "0"
@@ -285,6 +264,7 @@ Resources:
             source ~/venv/bin/activate
 
             pip install --upgrade pip
+            pip install wheel
 
             # Install Cloudformation helper scripts
             pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log

--- a/templates/jfrog-ami-master.template.yaml
+++ b/templates/jfrog-ami-master.template.yaml
@@ -16,7 +16,6 @@ Metadata:
           default: JFrog Product AMI info
         Parameters:
           - InstanceType
-          - VolumeSize
           - JFrogProduct
           - ArtifactoryVersion
       - Label:
@@ -34,8 +33,6 @@ Metadata:
         default: Availability zone
       InstanceType:
         default: EC2 instance type
-      VolumeSize:
-        default: EBS root volume size
       JFrogProduct:
         default: JFrog Product to install
       ArtifactoryVersion:
@@ -86,11 +83,6 @@ Parameters:
     ConstraintDescription: Must contain valid instance type.
     Default: m5.xlarge
     Type: String
-  VolumeSize:
-    Description: The size in GB of the available storage; the Quick Start will create an
-      Amazon Elastic Block Store (Amazon EBS) volumes of this size.
-    Default: 10
-    Type: Number
   QsS3BucketName:
     Description: S3 bucket name for the Quick Start assets. This string can include
       numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start
@@ -139,7 +131,6 @@ Resources:
         VpcId: !GetAtt VPCStack.Outputs.VpcId
         PublicSubnet1Id: !GetAtt VPCStack.Outputs.PublicSubnetID
         InstanceType: !Ref InstanceType
-        VolumeSize: !Ref VolumeSize
         JFrogProduct: !Ref JFrogProduct
         ArtifactoryVersion: !Ref ArtifactoryVersion
         QsS3BucketName: !Ref QsS3BucketName

--- a/templates/jfrog-artifactory-ec2-instance.template.yaml
+++ b/templates/jfrog-artifactory-ec2-instance.template.yaml
@@ -223,6 +223,7 @@ Resources:
 
                 if [[ $IS_PRIMARY != "true" ]]; then
                   echo 'Not primary node. Skipping EBS volume attachment.'
+                  lsblk # debug
                   exit 0
                 fi
 
@@ -370,7 +371,7 @@ Resources:
             source ~/venv/bin/activate
 
             pip install --upgrade pip
-            pip install jmespath wheel
+            pip install wheel
 
             # Install Cloudformation helper scripts
             pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log
@@ -400,8 +401,6 @@ Resources:
             /root/attach_volume.sh || cfn_fail
 
             ansible-galaxy collection install community.general ansible.posix
-
-            setsebool httpd_can_network_connect 1 -P
 
             aws secretsmanager get-secret-value --secret-id ${ArtifactoryLicensesSecretName} --region ${AWS::Region} | jq -r '{"artifactory_licenses":(.SecretString | fromjson )}' > ~/.jfrog_ami/licenses.json || cfn_fail
 

--- a/templates/jfrog-xray-ec2-instance.template.yaml
+++ b/templates/jfrog-xray-ec2-instance.template.yaml
@@ -286,6 +286,7 @@ Resources:
             source ~/venv/bin/activate
 
             pip install --upgrade pip
+            pip install wheel
 
             # Install Cloudformation helper scripts
             pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz 2>&1 | tee /var/log/userdata.aws_cfn_bootstrap_install.log
@@ -294,11 +295,16 @@ Resources:
 
             pip install ansible &> /var/log/userdata.ansible_install.log
 
-            setsebool httpd_can_network_connect 1 -P
-
             mkdir ~/.xray_ami
 
             aws s3 --region ${AWS::Region} sync s3://${QsS3BucketName}/${QsS3KeyPrefix}cloudInstallerScripts/ ~/.xray_ami/
+
+            setsebool httpd_can_network_connect 1 -P
+
+            # CentOS cloned virtual machines do not create a new machine id
+            # https://www.thegeekdiary.com/centos-rhel-7-how-to-change-the-machine-id/
+            rm -f /etc/machine-id
+            systemd-machine-id-setup
 
             cfn-init -v --stack ${AWS::StackName} --resource XrayLaunchConfiguration --configsets xray_install --region ${AWS::Region} || cfn_fail
 
@@ -307,10 +313,7 @@ Resources:
             chmod +x ./awslogs-agent-setup.py
             ./awslogs-agent-setup.py -n -r ${AWS::Region} -c /root/cloudwatch.conf
 
-            # CentOS cloned virtual machines do not create a new machine id
-            # https://www.thegeekdiary.com/centos-rhel-7-how-to-change-the-machine-id/
-            rm -f /etc/machine-id
-            systemd-machine-id-setup
+            lsblk # debug
 
             ansible-galaxy collection install community.general ansible.posix
 


### PR DESCRIPTION
- Remove ebs volume for ami creation for RT and Xray. The volumes aren't needed at this stage.
- Add volume mounting to Xray Ansible playbook. Looks like the mounted EBS volume for either RT or Xray instance (in CFT) were never mounted as partitions, thus they were just there not used.