### PR TITLE
Add AWS region to S3 endpoint field in template to ensure it works with GovCloud

### DIFF
--- a/cloudInstallerScripts/roles/artifactory/templates/binarystore.xml.j2
+++ b/cloudInstallerScripts/roles/artifactory/templates/binarystore.xml.j2
@@ -5,7 +5,7 @@
     </provider>
   </chain>
   <provider id="s3-storage-v3" type="s3-storage-v3">
-    <endpoint>s3.amazonaws.com</endpoint>
+    <endpoint>s3.{{ s3_region }}.amazonaws.com</endpoint>
     <bucketName>{{ s3_bucket }}</bucketName>
     <path>artifactory/filestore</path>
     <region>{{ s3_region }}</region>


### PR DESCRIPTION
The standard endpoint host name `s3.amazonaws.com` doesn't include the region so AWS assumes it is regular cloud, and thus breaks in GovCloud.

Now endpoint will include region always and will work for both regular or gov cloud.