### PR TITLE
Making the Database engine version parametrized.

### DIFF
--- a/templates/jfrog-artifactory-core-infrastructure.template.yaml
+++ b/templates/jfrog-artifactory-core-infrastructure.template.yaml
@@ -51,6 +51,8 @@ Parameters:
     Type: String
   DatabaseName:
     Type: String
+  EngineVersion:
+    Type: String
   InstanceType:
     Default: m5.xlarge
     Type: String
@@ -202,7 +204,7 @@ Resources:
       DBSubnetGroupName: !Ref  ArtifactoryDatabaseSubnetGroup
       Engine: Postgres
       PubliclyAccessible: false
-      EngineVersion: "11.14"
+      EngineVersion: !Ref EngineVersion
       MasterUsername: !Ref DatabaseUser
       MasterUserPassword: !Ref DatabasePassword
       MultiAZ: !Ref MultiAzDatabase


### PR DESCRIPTION
The version 11.14 of the RDS is no longer available. Lets make this as a parameter so that we can decide on the version of RDS we wish to use.